### PR TITLE
checks for babel polyfill

### DIFF
--- a/src/domregistry/DOMRegistry.js
+++ b/src/domregistry/DOMRegistry.js
@@ -51,13 +51,12 @@ export default class DOMRegistry {
         const componentNodes = this.element.querySelectorAll(component.nodeName);
 
         // Loop through each node and determine if we can render it.
-        var nodes = [].slice.call(componentNodes);
-        nodes.forEach(function (componentNode) {
+        Array.prototype.forEach.call(componentNodes, function(componentNode) {
             const canRender = this.traverseUpDom(componentNode);
             if (canRender) {
                 component.render(componentNode);
             }
-        });
+        }.bind(this));
     }
 
     /**

--- a/src/domregistry/DOMRegistry.js
+++ b/src/domregistry/DOMRegistry.js
@@ -51,7 +51,8 @@ export default class DOMRegistry {
         const componentNodes = this.element.querySelectorAll(component.nodeName);
 
         // Loop through each node and determine if we can render it.
-        componentNodes.forEach((componentNode) => {
+        var nodes = [].slice.call(componentNodes);
+        nodes.forEach(function (componentNode) {
             const canRender = this.traverseUpDom(componentNode);
             if (canRender) {
                 component.render(componentNode);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-import 'babel-polyfill';
+if (!global || !global._babelPolyfill) {
+    require('babel-polyfill')
+}
 
 import DOMModel from './dommodel/DOMModel';
 import DOMComponent from './domcomponent/DOMComponent'


### PR DESCRIPTION
Adds a check to ensure babel polyfill has not been defined. This ensures the script can be loaded in multiple webpack entries on the same page.