### PR TITLE
feature/auto dataset

### DIFF
--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -23,6 +23,19 @@ export default class DOMModel {
         this.props[name] = this.element.dataset[name];
     }
 
+    getAllDataAttributes(filter) {
+        const props = {...this.element.dataset};
+        
+        if (filter) {
+            if (typeof filter === 'string' || filter instanceof String) {
+                props = Object.keys(props).filter((key) => 
+                    key.toLowerCase().includes(filter.toLowerCase()));
+            }    
+        }
+
+        this.props = {...this.props, ...props};
+    }
+
     getAttribute(name, propName) {
         if (!propName) {
             propName = name;

--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -24,13 +24,25 @@ export default class DOMModel {
     }
 
     getAllDataAttributes(filter) {
-        const props = {...this.element.dataset};
-        
+        let props = {...this.element.dataset};
+
         if (filter) {
             if (typeof filter === 'string' || filter instanceof String) {
-                props = Object.keys(props).filter((key) => 
-                    key.toLowerCase().includes(filter.toLowerCase()));
-            }    
+                const filteredKeys =  Object.keys(props)
+                    .filter((key) => {
+                        return key.toLowerCase().includes(filter.toLowerCase());
+                    })
+                ;
+
+                if (filteredKeys.length) {
+                    props = filteredKeys.reduce((obj, key) => {
+                        return {
+                            ...obj,
+                            [key]: props[key]
+                        }
+                    }, {});
+                }
+            }
         }
 
         this.props = {...this.props, ...props};

--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -36,6 +36,10 @@ export default class DOMModel {
 
                 if (filteredKeys.length) {
                     props = filteredKeys.reduce((obj, key) => {
+                        if (props[key] === 'true' || props[key] === 'false') {
+                            props[key] === 'true' ? true : false;
+                        }
+
                         return {
                             ...obj,
                             [key]: props[key]

--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -47,7 +47,7 @@ export default class DOMModel {
 
         Object.keys(props).forEach((key) => {
             if (props[key] === 'true' || props[key] === 'false') {
-                props[key] === 'true' ? true : false;
+                props[key] = props[key] === 'true' ? true : false;
             }
         });
 

--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -36,10 +36,6 @@ export default class DOMModel {
 
                 if (filteredKeys.length) {
                     props = filteredKeys.reduce((obj, key) => {
-                        if (props[key] === 'true' || props[key] === 'false') {
-                            props[key] === 'true' ? true : false;
-                        }
-
                         return {
                             ...obj,
                             [key]: props[key]
@@ -48,6 +44,12 @@ export default class DOMModel {
                 }
             }
         }
+
+        Object.keys(props).forEach((key) => {
+            if (props[key] === 'true' || props[key] === 'false') {
+                props[key] === 'true' ? true : false;
+            }
+        });
 
         this.props = {...this.props, ...props};
     }


### PR DESCRIPTION
Adds `getAllDataAttributes` method to DOM model to automatically collect data props. Useful when teams are setting more than one data- attributes and want to automatically collect them.

Adds an optional filter to scope which dataset attributes are used, useful if a team would want to do some kind of known key in their data sets that get collected.