### PR TITLE
add element to props object

### DIFF
--- a/src/dommodel/DOMModel.js
+++ b/src/dommodel/DOMModel.js
@@ -6,6 +6,7 @@ export default class DOMModel {
     constructor(element) {
         this.props = {};
         this.element = element;
+        this.props.element = element;
         this.getId();
         this.getClassList();
         this.getChildNodes();


### PR DESCRIPTION
**What:**
Include `element` in _DOMModel_ `props` object  as well.

**Why:**
Functional Components are JS functions, so they don't have instances. They rely on `props` for data. Otherwise, if wanted to access the `element` one may need to do something like this:

```
class SomeComponentModel extends DOMModel {
    constructor(element) {
        super(element);
        this.props.element = element;
       // getAttributes here
    }
}
```

So that a Functional Component can access the `element` like this:

```
const SomeFunctionalComponent = ({ element }) => {
    // do something with the element here
}
```